### PR TITLE
Use a map state to process each freqmode separately

### DIFF
--- a/activate_l2/handler/activate_l2_handler.py
+++ b/activate_l2/handler/activate_l2_handler.py
@@ -53,8 +53,8 @@ def activate_l2_handler(event: Event, context: Context) -> dict[str, int]:
 
     sfn.start_execution(
         stateMachineArn=state_machine_arn,
-        input=json.dumps({"Scans": event["Scans"]}),
-        name=f"{filename}-{create_short_hash()}",
+        input=json.dumps({"Scans": event["ScansData"]}),
+        name=f"{filename}-{event['FreqMode']}-{create_short_hash()}",
     )
 
     return {

--- a/cache_tables/handler/scans_info.py
+++ b/cache_tables/handler/scans_info.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from time import sleep
 from tempfile import TemporaryDirectory
 from typing import Any
 
@@ -73,22 +72,15 @@ class RetriesExhaustedError(Exception):
 def get_odin_data(
     endpoint: str,
     api_base: str = API_BASE,
-    max_retries: int = MAX_RETRIES,
 ) -> dict:
     url = f"{api_base}/{endpoint}"
-    retries = max_retries
-    while retries > 0:
-        try:
-            response = requests.get(url, timeout=365)
-            response.raise_for_status()
-            break
-        except (HTTPError, RequestException) as msg:
-            retries -= 1
-            if retries == 0:
-                raise RetriesExhaustedError(
-                    f"Retries exhausted for {url} ({msg})"
-                )
-            sleep(SLEEP_TIME * 2 ** (MAX_RETRIES - retries - 1))
+    try:
+        response = requests.get(url, timeout=365)
+        response.raise_for_status()
+    except (HTTPError, RequestException) as msg:
+        raise RetriesExhaustedError(
+            f"Retries exhausted for {url} ({msg})"
+        )
     return response.json()
 
 

--- a/cache_tables/handler/scans_info.py
+++ b/cache_tables/handler/scans_info.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 import requests
+from requests.exceptions import HTTPError, RequestException
 
 from .odin_connection import odin_connection, setup_postgres
 from .ssm_parameters import get_parameters
@@ -75,13 +76,13 @@ def get_odin_data(
     max_retries: int = MAX_RETRIES,
 ) -> dict:
     url = f"{api_base}/{endpoint}"
-    response = requests.get(url, timeout=365)
     retries = max_retries
     while retries > 0:
         try:
+            response = requests.get(url, timeout=365)
             response.raise_for_status()
             break
-        except requests.exceptions.HTTPError as msg:
+        except (HTTPError, RequestException) as msg:
             retries -= 1
             if retries == 0:
                 raise RetriesExhaustedError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,45 +8,45 @@ attrs==23.1.0
     # via
     #   cattrs
     #   jsii
-aws-cdk-asset-awscli-v1==2.2.199
+aws-cdk-asset-awscli-v1==2.2.200
     # via aws-cdk-lib
 aws-cdk-asset-kubectl-v20==2.1.2
     # via aws-cdk-lib
-aws-cdk-asset-node-proxy-agent-v5==2.0.165
+aws-cdk-asset-node-proxy-agent-v6==2.0.1
     # via aws-cdk-lib
-aws-cdk-lib==2.86.0
+aws-cdk-lib==2.97.0
     # via -r requirements.in
-boto3==1.26.165
+boto3==1.28.53
     # via -r requirements.in
-botocore==1.29.165
+botocore==1.31.53
     # via
     #   -r requirements.in
     #   boto3
     #   s3transfer
 cattrs==23.1.2
     # via jsii
-constructs==10.2.67
+constructs==10.2.70
     # via aws-cdk-lib
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via cattrs
-importlib-resources==5.12.0
+importlib-resources==6.1.0
     # via jsii
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsii==1.84.0
+jsii==1.89.0
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20
-    #   aws-cdk-asset-node-proxy-agent-v5
+    #   aws-cdk-asset-node-proxy-agent-v6
     #   aws-cdk-lib
     #   constructs
 publication==0.0.3
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20
-    #   aws-cdk-asset-node-proxy-agent-v5
+    #   aws-cdk-asset-node-proxy-agent-v6
     #   aws-cdk-lib
     #   constructs
     #   jsii
@@ -54,7 +54,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   jsii
-s3transfer==0.6.1
+s3transfer==0.6.2
     # via boto3
 six==1.16.0
     # via python-dateutil
@@ -62,11 +62,11 @@ typeguard==2.13.3
     # via
     #   aws-cdk-asset-awscli-v1
     #   aws-cdk-asset-kubectl-v20
-    #   aws-cdk-asset-node-proxy-agent-v5
+    #   aws-cdk-asset-node-proxy-agent-v6
     #   aws-cdk-lib
     #   constructs
     #   jsii
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   cattrs
     #   jsii

--- a/stacks/odincal_stack.py
+++ b/stacks/odincal_stack.py
@@ -1,5 +1,5 @@
 from aws_cdk import Duration, Stack
-from aws_cdk_lib import aws_stepfunctions as sfn
+from aws_cdk import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as tasks
 from aws_cdk.aws_ec2 import Vpc, SubnetSelection, SubnetType
 from aws_cdk.aws_iam import Effect, PolicyStatement

--- a/stacks/odincal_stack.py
+++ b/stacks/odincal_stack.py
@@ -217,7 +217,7 @@ class OdincalStack(Stack):
             errors=["States.ALL"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(1),
+            interval=Duration.minutes(6),
         )
 
         job_info_level1_task = tasks.LambdaInvoke(
@@ -242,13 +242,13 @@ class OdincalStack(Stack):
             errors=["Level1BPrepareDataError"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(10),
+            interval=Duration.minutes(12),
         )
         job_info_level1_task.add_retry(
             errors=["States.ALL"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(1),
+            interval=Duration.minutes(6),
         )
 
         calibrate_level1_task = tasks.LambdaInvoke(
@@ -273,7 +273,7 @@ class OdincalStack(Stack):
             errors=["States.ALL"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(1),
+            interval=Duration.minutes(6),
         )
 
         date_info_task = tasks.LambdaInvoke(
@@ -294,7 +294,7 @@ class OdincalStack(Stack):
             errors=["States.ALL"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(1),
+            interval=Duration.minutes(6),
         )
 
         scans_info_task = tasks.LambdaInvoke(
@@ -307,13 +307,13 @@ class OdincalStack(Stack):
             errors=["RetriesExhaustedError"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(10),
+            interval=Duration.minutes(12),
         )
         scans_info_task.add_retry(
             errors=["States.ALL"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(1),
+            interval=Duration.minutes(6),
         )
 
         activate_level2_task = tasks.LambdaInvoke(
@@ -334,7 +334,7 @@ class OdincalStack(Stack):
             errors=["States.ALL"],
             max_attempts=4,
             backoff_rate=2,
-            interval=Duration.minutes(1),
+            interval=Duration.minutes(6),
         )
 
         # Set up workflow

--- a/stacks/odincal_stack.py
+++ b/stacks/odincal_stack.py
@@ -1,5 +1,5 @@
 from aws_cdk import Duration, Stack
-from aws_cdk import aws_stepfunctions as sfn
+from aws_cdk_lib import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as tasks
 from aws_cdk.aws_ec2 import Vpc, SubnetSelection, SubnetType
 from aws_cdk.aws_iam import Effect, PolicyStatement
@@ -215,9 +215,11 @@ class OdincalStack(Stack):
         )
         preprocess_level1_task.add_retry(
             errors=["States.ALL"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(6),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
 
         job_info_level1_task = tasks.LambdaInvoke(
@@ -240,15 +242,19 @@ class OdincalStack(Stack):
         )
         job_info_level1_task.add_retry(
             errors=["Level1BPrepareDataError"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(12),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
         job_info_level1_task.add_retry(
             errors=["States.ALL"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(6),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
 
         calibrate_level1_task = tasks.LambdaInvoke(
@@ -271,9 +277,11 @@ class OdincalStack(Stack):
         )
         calibrate_level1_task.add_retry(
             errors=["States.ALL"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(6),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
 
         date_info_task = tasks.LambdaInvoke(
@@ -292,9 +300,11 @@ class OdincalStack(Stack):
         )
         date_info_task.add_retry(
             errors=["States.ALL"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(6),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
 
         scans_info_task = tasks.LambdaInvoke(
@@ -305,15 +315,19 @@ class OdincalStack(Stack):
         )
         scans_info_task.add_retry(
             errors=["RetriesExhaustedError"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(12),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
         scans_info_task.add_retry(
             errors=["States.ALL"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(6),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
 
         activate_level2_task = tasks.LambdaInvoke(
@@ -332,9 +346,11 @@ class OdincalStack(Stack):
         )
         activate_level2_task.add_retry(
             errors=["States.ALL"],
-            max_attempts=4,
+            max_attempts=42,
             backoff_rate=2,
             interval=Duration.minutes(6),
+            max_delay=Duration.minutes(42),
+            jitter_strategy=sfn.JitterType.FULL,
         )
 
         # Set up workflow


### PR DESCRIPTION
Changes so that the final step, updating the `scans_cache` table, is done using a `Map` state. This lets us process each frequency mode separately. In addition a few small things have been fixed in the inputs/outputs etc.

Total run time for the whole chain for a fairly large `AC1` file was just short of 19 minutes, start to finish.

# Advantages
- Less load on database: I can make quicker requests and only insert what needs to be inserted
- Less chance of Lambda timeouts: each step is a few minutes, but together all freq modes would have come close to the allowed 15 minutes,
- Less data for Level 2 to filter: By sending only data for one freq mode, and only if there is data, the logic in Level 2 can be simplified.

# Outstanding issues
- I'm not entirely sure if the data sent to L2 will be correct, but if it isn't I think I know how to fix it.
- The status of the `Map` isn't explicitly checked, but if "iterations" fail, it will fail the whole state machine, which seems good enough, at least for now.
- There is quite a lot of data being copied in what seems unnecessary ways between states, in order for the `Map` processes to have the data they need. There should be neater ways to fix this, but I have yet to work them out.

# Bonus
![image](https://github.com/Odin-SMR/odincal-lambda/assets/358614/deb8aeb3-0583-4ce9-9985-ce17f42bb152)
