### PR TITLE
FM and scanids for Level 2

### DIFF
--- a/activate_l2/handler/activate_l2_handler.py
+++ b/activate_l2/handler/activate_l2_handler.py
@@ -58,7 +58,8 @@ def activate_l2_handler(event: Event, context: Context) -> dict[str, int]:
                 "ScanIDs": event["ScanIDs"],
                 "File": filename,
                 "Backend": event["Backend"],
-            }),
+            }
+        ),
         name=f"{filename}-{create_short_hash()}",
     )
 

--- a/create_zpt/handler/get_scan_ids_handler.py
+++ b/create_zpt/handler/get_scan_ids_handler.py
@@ -1,19 +1,23 @@
-"""Extract just the scan IDs from input
+"""Extract just the scan IDs and frequency modes from input
 """
 from typing import Any
 
 
 def handler(event: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
-    scan_ids: set[int] = set()
+    scans: set[tuple[int, int]] = set()
     for fm in event["ScansInfo"]:
-        scan_ids = scan_ids.union({scan["ScanID"] for scan in fm["ScansInfo"]})
+        scans = scans.union(
+            {(scan["ScanID"], fm["FreqMode"]) for scan in fm["ScansInfo"]}
+        )
 
-    if len(scan_ids) == 0:
+    if len(scans) == 0:
         return {
             "StatusCode": 204,
             "ScanIDs": [],
         }
     return {
         "StatusCode": 200,
-        "ScanIDs": list(scan_ids),
+        "ScanIDs": [
+            {"ScanID": s[0], "FreqMode": s[1]} for s in scans
+        ]
     }

--- a/create_zpt/handler/get_scan_ids_handler.py
+++ b/create_zpt/handler/get_scan_ids_handler.py
@@ -7,7 +7,7 @@ def handler(event: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
     scans: set[tuple[int, int]] = set()
     for fm in event["ScansInfo"]:
         scans = scans.union(
-            {(scan["ScanID"], fm["FreqMode"]) for scan in fm["ScansInfo"]}
+            {(scan["ScanID"], scan["FreqMode"]) for scan in fm["ScansInfo"]}
         )
 
     if len(scans) == 0:


### PR DESCRIPTION
This collects frequency modes along with scan ids for sending to Level 2 (previously just scanids).

In addition, this collection is now performed before ZPT creation, in order to exit early, if the result is that there are no scans to forward (can happen, if for instance all scans are FM0).