### PR TITLE
Try to load key to provoke error

### DIFF
--- a/cache_tables/handler/scans_info.py
+++ b/cache_tables/handler/scans_info.py
@@ -109,6 +109,7 @@ def update_scans(
         ))
         if scan_log is None:
             continue
+        scan_log = scan_log["Data"]
 
         db_connection = odin_connection(pg_credentials)
         db_cursor = db_connection.cursor()

--- a/cache_tables/handler/scans_info.py
+++ b/cache_tables/handler/scans_info.py
@@ -100,9 +100,13 @@ def update_scans(
     freqmode = int(date_info["FreqMode"])
     if freqmode == 0:
         return []
+    scan_url = "rest_api/v5/level1/{freqmode}/{scan_id}/Log"
 
     for scan_id in date_info["Scans"]:
-        scan_log = get_odin_data(f"rest_api/v5/{freqmode}/{scan_id}/Log")
+        scan_log = get_odin_data(scan_url.format(
+            freqmode=freqmode,
+            scan_id=scan_id,
+        ))
         if scan_log is None:
             continue
 

--- a/cache_tables/handler/scans_info.py
+++ b/cache_tables/handler/scans_info.py
@@ -83,7 +83,7 @@ def get_odin_data(
 ) -> dict:
     url = f"{api_base}/{endpoint}"
     try:
-        response = requests.get(url, timeout=365)
+        response = requests.get(url)
         response.raise_for_status()
     except (HTTPError, RequestException) as msg:
         raise RetriesExhaustedError(f"Retries exhausted for {url} ({msg})")
@@ -97,43 +97,43 @@ def update_scans(
     """Populate database with 'cached' scans for each day."""
 
     all_scans = []
-    freqmode = date_info["FreqMode"]
+    freqmode = int(date_info["FreqMode"])
     if freqmode == 0:
         return []
-    date_str = date_info["DateString"]
 
-    scans_api = f"rest_api/v5/freqmode_raw/{date_str}/{freqmode}/"
-    scan_data = get_odin_data(scans_api)
+    for scan_id in date_info["Scans"]:
+        scan_log = get_odin_data(f"rest_api/v5/{freqmode}/{scan_id}/Log")
+        if scan_log is None:
+            continue
 
-    db_connection = odin_connection(pg_credentials)
-    db_cursor = db_connection.cursor()
+        db_connection = odin_connection(pg_credentials)
+        db_cursor = db_connection.cursor()
 
-    for scan in scan_data["Data"]:
-        if scan["ScanID"] in date_info["Scans"]:
-            add_to_database(
-                db_cursor,
-                dt.date.fromisoformat(date_str),
-                date_info["FreqMode"],
-                date_info["Backend"],
-                scan["AltEnd"],
-                scan["AltStart"],
-                scan["DateTime"],
-                scan["LatEnd"],
-                scan["LatStart"],
-                scan["LonEnd"],
-                scan["LonStart"],
-                scan["MJDEnd"],
-                scan["MJDStart"],
-                scan["NumSpec"],
-                scan["ScanID"],
-                scan["SunZD"],
-                scan["Quality"],
-            )
-            all_scans.append(scan)
+        add_to_database(
+            db_cursor,
+            dt.date.fromisoformat(scan_log["DateTime"]),
+            date_info["FreqMode"],
+            date_info["Backend"],
+            scan_log["AltEnd"],
+            scan_log["AltStart"],
+            scan_log["DateTime"],
+            scan_log["LatEnd"],
+            scan_log["LatStart"],
+            scan_log["LonEnd"],
+            scan_log["LonStart"],
+            scan_log["MJDEnd"],
+            scan_log["MJDStart"],
+            scan_log["NumSpec"],
+            scan_log["ScanID"],
+            scan_log["SunZD"],
+            scan_log["Quality"],
+        )
 
-    db_connection.commit()
-    db_cursor.close()
-    db_connection.close()
+        db_connection.commit()
+        db_cursor.close()
+        db_connection.close()
+
+        all_scans.append(scan_log)
 
     return all_scans
 

--- a/cache_tables/handler/scans_info.py
+++ b/cache_tables/handler/scans_info.py
@@ -18,12 +18,11 @@ SLEEP_TIME = 60  # seconds
 
 def add_to_database(
     cursor,
-    day: dt.date,
+    datetime_i: dt.datetime,
     freqmode: int,
     backend: str,
     altend: float,
     altstart: float,
-    datetime_i: dt.datetime,
     latend: float,
     latstart: float,
     lonend: float,
@@ -52,7 +51,7 @@ def add_to_database(
         "created=EXCLUDED.created, "
         "quality=EXCLUDED.quality ",
         (
-            day,
+            datetime_i.date(),
             freqmode,
             backend,
             scanid,
@@ -67,7 +66,7 @@ def add_to_database(
             numspec,
             sunzd,
             datetime_i,
-            dt.datetime.now(),
+            dt.datetime.utcnow(),
             quality,
         ),
     )
@@ -113,15 +112,14 @@ def update_scans(
 
         db_connection = odin_connection(pg_credentials)
         db_cursor = db_connection.cursor()
-
+        scan_datetime = dt.datetime.fromisoformat(scan_log["DateTime"])
         add_to_database(
             db_cursor,
-            dt.date.fromisoformat(scan_log["DateTime"]),
+            scan_datetime,
             date_info["FreqMode"],
             date_info["Backend"],
             scan_log["AltEnd"],
             scan_log["AltStart"],
-            scan_log["DateTime"],
             scan_log["LatEnd"],
             scan_log["LatStart"],
             scan_log["LonEnd"],

--- a/create_zpt/handler/check_era5_handler.py
+++ b/create_zpt/handler/check_era5_handler.py
@@ -30,7 +30,7 @@ def assert_era5_exists(
                 month=date.month,
                 date=date.isoformat(),
             ),
-        )
+        ).load()
     except ClientError as err:
         raise NoERA5DataError(f"No ERA5 data found for {date} ({err})")
 


### PR DESCRIPTION
Forgot trying to load the assigned object. This provokes the error for non-existent keys, so without it the check never fails. Note, however, that the retry has this setting:

``` python
        check_era5_task.add_retry(
            errors=["NoERA5DataError"],
            max_attempts=42,
            backoff_rate=2,
            interval=Duration.hours(1),
            max_delay=Duration.hours(24),
            jitter_strategy=sfn.JitterType.FULL,
        )
```
which probably works, but is not well thought out.

See also for Solar data:
``` python
        check_solar_task.add_retry(
            errors=["NoSolarDataError"],
            max_attempts=42,
            backoff_rate=2,
            interval=Duration.hours(1),
            max_delay=Duration.hours(24),
            jitter_strategy=sfn.JitterType.FULL,
        )
```
though this probably works better, since there is no delay in Solar data in the same way.

I think the Solar retry is probably  OK, but the ERA5 retry should maybe be tweaked. Suggestions welcome!