### PR TITLE
Remove duplicates from scansinfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           env:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: eu-north-1
           run: |
             tox
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
             pip install tox
 
         - name: Run unit tests
+          env:
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           run: |
             tox
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           env:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-            AWS_REGION: eu-north-1
           run: |
             tox
 

--- a/create_zpt/handler/check_zpt_handler.py
+++ b/create_zpt/handler/check_zpt_handler.py
@@ -7,7 +7,6 @@ import boto3
 from botocore.exceptions import ClientError
 from .log_configuration import logconfig
 
-logconfig()
 
 ZPT_BUCKET = "odin-zpt"
 ZPT_PATTERN = "{backend}/{prefix}/{filename}.parquet"
@@ -38,6 +37,7 @@ def assert_zpt_exists(
 
 
 def handler(event: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    logconfig()
     filename = os.path.split(event["name"])[-1]
     prefix = filename[0:3]
     backend = event["type"]

--- a/create_zpt/handler/create_zpt_handler.py
+++ b/create_zpt/handler/create_zpt_handler.py
@@ -28,7 +28,7 @@ def get_scan_data(scans_info: list[dict[str, Any]]) -> DataArray:
     for d in scans_info:
         data.extend(d["ScansInfo"])
 
-    df = DataFrame.from_records(data)
+    df = DataFrame.from_records(data).drop_duplicates()
     df["MJDMid"] = (df["MJDStart"] + df["MJDEnd"]) * 0.5
     df["LatMid"], df["LonMid"] = get_scan_geo_loc(
         df["LatStart"],

--- a/create_zpt/handler/create_zpt_handler.py
+++ b/create_zpt/handler/create_zpt_handler.py
@@ -18,7 +18,6 @@ from .geos import gmh
 from .scan_data_descriptions import parameter_desc
 from .log_configuration import logconfig
 
-logconfig()
 
 AWS_REGION = "eu-north-1"
 
@@ -58,6 +57,7 @@ def get_scan_data(scans_info: list[dict[str, Any]]) -> DataArray:
 
 
 def handler(event: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    logconfig()
     scans = get_scan_data(event["ScansInfo"])
 
     dates: list[dt.date] = list(set(

--- a/create_zpt/requirements.txt
+++ b/create_zpt/requirements.txt
@@ -15,10 +15,10 @@ jmespath==1.0.1
 multidict==6.0.4
 nrlmsise00==0.1.2
 numcodecs==0.12.1
-numpy==1.26.1
+numpy==1.26.2
 packaging==23.2
-pandas==2.1.2
-pyarrow==14.0.0
+pandas==2.1.3
+pyarrow==14.0.1
 python-dateutil==2.8.2
 pytz==2023.3.post1
 pyyaml==6.0.1
@@ -27,7 +27,7 @@ scipy==1.11.3
 six==1.16.0
 tzdata==2023.3
 urllib3==2.0.7
-wrapt==1.15.0
+wrapt==1.16.0
 xarray==2023.10.1
 yarl==1.9.2
 zarr==2.16.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,20 @@
+aiobotocore==2.7.0
+    # via s3fs
+aiohttp==3.8.6
+    # via
+    #   aiobotocore
+    #   s3fs
+aioitertools==0.11.0
+    # via aiobotocore
+aiosignal==1.3.1
+    # via aiohttp
 asciitree==0.3.3
     # via zarr
+async-timeout==4.0.3
+    # via aiohttp
 attrs==23.1.0
     # via
-    #   -r odincal/requirements.in
+    #   aiohttp
     #   cattrs
     #   jsii
 aws-cdk-asset-awscli-v1==2.2.201
@@ -11,25 +23,23 @@ aws-cdk-asset-kubectl-v20==2.1.2
     # via aws-cdk-lib
 aws-cdk-asset-node-proxy-agent-v6==2.0.1
     # via aws-cdk-lib
-aws-cdk-lib==2.104.0
+aws-cdk-lib==2.106.1
     # via -r requirements.in
 aws-psycopg2==1.3.8
     # via -r cache_tables/requirements.in
-black==23.10.1
+black==23.11.0
     # via -r requirements-dev.in
-boto3==1.28.78
-    # via
-    #   -r odincal/requirements.in
-    #   -r requirements.in
-boto3-stubs==1.28.78
+boto3==1.28.64
+    # via -r requirements.in
+boto3-stubs==1.28.84
     # via -r requirements-dev.in
-botocore==1.31.78
+botocore==1.31.64
     # via
     #   -r requirements.in
+    #   aiobotocore
     #   boto3
-    #   s3fs
     #   s3transfer
-botocore-stubs==1.31.78
+botocore-stubs==1.31.84
     # via boto3-stubs
 build==1.0.3
     # via pip-tools
@@ -42,7 +52,9 @@ certifi==2023.7.22
 chardet==5.2.0
     # via tox
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.7
     # via
     #   black
@@ -63,13 +75,17 @@ filelock==3.13.1
     # via
     #   tox
     #   virtualenv
+frozenlist==1.4.0
+    # via
+    #   aiohttp
+    #   aiosignal
 fsspec==2023.10.0
     # via s3fs
-greenlet==3.0.1
-    # via sqlalchemy
 idna==3.4
-    # via requests
-importlib-resources==6.1.0
+    # via
+    #   requests
+    #   yarl
+importlib-resources==6.1.1
     # via jsii
 iniconfig==2.0.0
     # via pytest
@@ -86,9 +102,13 @@ jsii==1.91.0
     #   constructs
 mockito==1.4.0
     # via -r requirements-dev.in
-mypy==1.6.1
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
+mypy==1.7.0
     # via -r requirements-dev.in
-mypy-boto3-lambda==1.28.63
+mypy-boto3-lambda==1.28.83
     # via boto3-stubs
 mypy-boto3-s3==1.28.55
     # via boto3-stubs
@@ -102,9 +122,8 @@ nrlmsise00==0.1.2
     # via -r create_zpt/requirements.in
 numcodecs==0.12.1
     # via zarr
-numpy==1.26.1
+numpy==1.26.2
     # via
-    #   -r odincal/requirements.in
     #   nrlmsise00
     #   numcodecs
     #   pandas
@@ -120,10 +139,9 @@ packaging==23.2
     #   pytest
     #   tox
     #   xarray
-pandas==2.1.2
+pandas==2.1.3
     # via
     #   -r create_zpt/requirements.in
-    #   -r odincal/requirements.in
     #   xarray
 pathspec==0.11.2
     # via black
@@ -138,8 +156,6 @@ pluggy==1.3.0
     # via
     #   pytest
     #   tox
-psycopg2-binary==2.9.9
-    # via -r odincal/requirements.in
 publication==0.0.3
     # via
     #   aws-cdk-asset-awscli-v1
@@ -148,12 +164,8 @@ publication==0.0.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-pyarrow==14.0.0
+pyarrow==14.0.1
     # via -r create_zpt/requirements.in
-pygresql==6.0
-    # via -r odincal/requirements.in
-pyinotify==0.9.6
-    # via -r odincal/requirements.in
 pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
@@ -171,10 +183,9 @@ pyyaml==6.0.1
     # via
     #   -r cache_tables/requirements.in
     #   -r create_zpt/requirements.in
-    #   -r odincal/requirements.in
 requests==2.31.0
     # via -r cache_tables/requirements.in
-s3fs==0.4.2
+s3fs==2023.10.0
     # via -r create_zpt/requirements.in
 s3transfer==0.7.0
     # via boto3
@@ -182,8 +193,6 @@ scipy==1.11.3
     # via -r create_zpt/requirements.in
 six==1.16.0
     # via python-dateutil
-sqlalchemy==2.0.23
-    # via -r odincal/requirements.in
 tomli==2.0.1
     # via
     #   black
@@ -204,7 +213,7 @@ typeguard==2.13.3
     #   aws-cdk-lib
     #   constructs
     #   jsii
-types-awscrt==0.19.8
+types-awscrt==0.19.10
     # via botocore-stubs
 types-psycopg2==2.9.21.15
     # via -r requirements-dev.in
@@ -226,7 +235,6 @@ typing-extensions==4.8.0
     #   mypy-boto3-lambda
     #   mypy-boto3-s3
     #   mypy-boto3-stepfunctions
-    #   sqlalchemy
 tzdata==2023.3
     # via pandas
 urllib3==1.26.18
@@ -238,8 +246,12 @@ virtualenv==20.24.6
     # via tox
 wheel==0.41.3
     # via pip-tools
+wrapt==1.16.0
+    # via aiobotocore
 xarray==2023.10.1
     # via -r create_zpt/requirements.in
+yarl==1.9.2
+    # via aiohttp
 zarr==2.16.1
     # via -r create_zpt/requirements.in
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,13 @@ attrs==23.1.0
 aws-cdk-asset-awscli-v1==2.2.201
 aws-cdk-asset-kubectl-v20==2.1.2
 aws-cdk-asset-node-proxy-agent-v6==2.0.1
-aws-cdk-lib==2.104.0
-boto3==1.28.78
-botocore==1.31.78
+aws-cdk-lib==2.106.1
+boto3==1.28.84
+botocore==1.31.84
 cattrs==23.1.2
 constructs==10.3.0
 exceptiongroup==1.1.3
-importlib-resources==6.1.0
+importlib-resources==6.1.1
 jmespath==1.0.1
 jsii==1.91.0
 publication==0.0.3

--- a/tests/test_create_zpt.py
+++ b/tests/test_create_zpt.py
@@ -1,0 +1,48 @@
+from create_zpt.handler.create_zpt_handler import get_scan_data
+
+# Dataset from a failed statemachine, is this a split scan?
+scans = [
+    {"StatusCode": 204, "ScansInfo": []},
+    {
+        "StatusCode": 200,
+        "ScansInfo": [
+            {
+                "AltStart": 106905.08,
+                "AltEnd": 9460.85,
+                "LatStart": 71.514114,
+                "LatEnd": 61.195534,
+                "LonStart": 182.94179,
+                "LonEnd": 173.09192,
+                "MJDStart": 60244.8251785,
+                "MJDEnd": 60244.8267748,
+                "ScanID": 14272782480,
+                "FreqMode": 21,
+                "Backend": "AC1",
+            },
+        ],
+    },
+    {"StatusCode": 204, "ScansInfo": []},
+    {
+        "StatusCode": 200,
+        "ScansInfo": [
+            {
+                "AltStart": 106905.08,
+                "AltEnd": 9460.85,
+                "LatStart": 71.514114,
+                "LatEnd": 61.195534,
+                "LonStart": 182.94179,
+                "LonEnd": 173.09192,
+                "MJDStart": 60244.8251785,
+                "MJDEnd": 60244.8267748,
+                "ScanID": 14272782480,
+                "FreqMode": 21,
+                "Backend": "AC1",
+            },
+        ],
+    },
+]
+
+
+def test_get_scan_data():
+    data = get_scan_data(scans)
+    assert (1,) == data.ScanID.shape

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,6 @@ envlist = py310,mypy,lint
 skipsdist = True
 
 [testenv:py310]
-pass_env =
-    AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY
-    AWS_PROFILE
-    AWS_REGION
 deps =
     -rrequirements-dev.txt
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,18 @@
 envlist = py310,mypy,lint
 skipsdist = True
 
-# [testenv:py310]
-# deps =
-#     -rrequirements-dev.txt
-#     pytest
-# setenv =
-#     TZ = utc
-# commands =
-#     pytest tests {posargs}
+[testenv:py310]
+pass_env =
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_PROFILE
+deps =
+    -rrequirements-dev.txt
+    pytest
+setenv =
+    TZ = utc
+commands =
+    pytest tests {posargs}
 
 [testenv:mypy]
 basepython = python3.10
@@ -33,3 +37,4 @@ max_line_length = 88
 filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
+addopts = --ignore=cdk.out --ignore=odincal

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ pass_env =
     AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY
     AWS_PROFILE
+    AWS_REGION
 deps =
     -rrequirements-dev.txt
     pytest


### PR DESCRIPTION
* Remove duplicate information in scansinfo.

The error message indicated the data was not 1-D, because the filter on scanid filtered out two scanids with the same information, i.e. 2-D data.

fix #15 